### PR TITLE
chore: Update xmldom 0.3.0 to @xmldom/xmldom 0.8.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "@island.is/login",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@island.is/login",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "license": "MIT",
             "dependencies": {
                 "@fidm/x509": "^1.2.1",
+                "@xmldom/xmldom": "^0.8.10",
                 "xml-crypto": "^2.0.0",
-                "xml2js": "^0.4.23",
-                "xmldom": "^0.3.0"
+                "xml2js": "^0.4.23"
             },
             "devDependencies": {
                 "eslint-config-prettier": "^8.8.0",
@@ -1282,6 +1282,14 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
+        },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
         },
         "node_modules/acorn": {
             "version": "8.9.0",
@@ -4353,14 +4361,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/xmldom": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-            "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/xpath": {
             "version": "0.0.27",
             "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
@@ -5419,6 +5419,11 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
+        },
+        "@xmldom/xmldom": {
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
         },
         "acorn": {
             "version": "8.9.0",
@@ -7665,11 +7670,6 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-        },
-        "xmldom": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-            "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
         },
         "xpath": {
             "version": "0.0.27",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "homepage": "https://github.com/mojoweb/islandis-login#readme",
     "dependencies": {
         "@fidm/x509": "^1.2.1",
+        "@xmldom/xmldom": "^0.8.10",
         "xml-crypto": "^2.0.0",
-        "xml2js": "^0.4.23",
-        "xmldom": "^0.3.0"
+        "xml2js": "^0.4.23"
     },
     "devDependencies": {
         "eslint-config-prettier": "^8.8.0",

--- a/src/validateSignature.js
+++ b/src/validateSignature.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const { xpath } = require("xml-crypto");
-const { DOMParser } = require("xmldom");
+const { DOMParser } = require("@xmldom/xmldom");
 const { SignedXml } = require("xml-crypto");
 const { Certificate } = require("@fidm/x509");
 const { readFileSync } = require("fs");


### PR DESCRIPTION
Fixes a an issue discussed [here](https://nvd.nist.gov/vuln/detail/CVE-2022-39299) where xmldom is identified as a root cause.

xmldom is now published as @xmldom/xmldom as explained https://github.com/xmldom/xmldom/issues/271